### PR TITLE
declaration for "$maxn_fraction"

### DIFF
--- a/trim_galore
+++ b/trim_galore
@@ -37,7 +37,7 @@ my $last_modified = "28 01 2023";
 
 my $cutadapt_version;
 my $python_version;
-
+my $maxn_fraction;
 
 my ($compression_path,$decompression_path,$cores,$cutoff,$adapter,$stringency,$rrbs,$length_cutoff,$keep,$fastqc,$non_directional,$phred_encoding,$fastqc_args,$trim,$gzip,$validate,$retain,$length_read_1,$length_read_2,$a2,$error_rate,$output_dir,$no_report_file,$dont_gzip,$clip_r1,$clip_r2,$three_prime_clip_r1,$three_prime_clip_r2,$nextera,$stranded_illumina,$small_rna,$path_to_cutadapt,$illumina,$max_length,$maxn,$trim_n,$hardtrim5,$clock,$polyA,$hardtrim3,$nextseq,$basename,$consider_already_trimmed,$umi_from_r2) = process_commandline();
 


### PR DESCRIPTION
Fixing a minor bug. Just added a declaration for "$maxn_fraction"

```bash
Global symbol "$maxn_fraction" requires explicit package name (did you forget to declare "my $maxn_fraction"?) at ./trim_galore line 657.
```